### PR TITLE
Integrate project with codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,21 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+  brakeman:
+    enabled: false
+  rubymotion:
+    enabled: true
+ratings:
+  paths:
+  - "**.module"
+  - "**.rb"
+exclude_paths:
+- spec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,12 @@ before_install: gem install bundler -v 1.11.2
 branches:
   only:
     - master
+
+# This section was added as per https://docs.travis-ci.com/user/code-climate/
+# To protect our codeclimate stats rather than adding the Codeclimate API key for ea-area_lookup
+# in the open we used this guide https://docs.travis-ci.com/user/encryption-keys/ to encryt the
+# value. Essentially install travis gem, then run `travis encrypt <my_code_climate_api_key>`
+addons:
+  code_climate:
+    repo_token:
+      secure: "NHoT4H5wYUhdGoByjcnViaLzHFkxKgSgZPCNtWtaCdrWXUwX8VLYYl6NPqvANMII0z81Fq8P0+Nzo0o0YfWAvXsimsuhXd4hdzMSKW+xp6G5KRmCaU8FfIjqGhf0yYs3jmTD6Bz2rv1uhZ080k39OXBE/pGR3pkd229lVxrVR91zYYnERqNGD7p78NDGCTPlyoYYNB+wMLq76p6Hl2dSZgwMQtDS/Qi95vG+3Zq2y3z+iarlXSxm2xqfYMgUTcoO3w1eL2P/I+y/SqKgqKEpNKTzicFySUUg5NEvQy/GQit6iArkemU3q364fp4RqkUzauDenEsE64Q6MNY/n7Pj+ZVUKvT3mFKr2OAQojrJko2vtM7QuxBKmaRvkA89JRJvXDTREqbB1gY9pmnAbxBQbRW25KRSucKRPIGhK+gfwjM01eINveR86KECyTOLkrVcWFihrXzrIxLzv37UQUh9UVE/+aca0QVivYa6jJOebPKeLxS3sPLco8clv4A1H7HfvAkzg9lzWC6cz/cSOmQWWvAcDsd+riMaq188fCGuPhHcGywzwH4qt/75b8vnOoOSZSxqNAvQfsf0np0V+N2ahiGqpBhTgPKD3B+Mhff2KN0WY0eejzUMdPdi6zNcjJySyvLBZ9Jrmb+Vf/X1DhEqg05n/V2lQCWzoeJw4zSyRyU="

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ ruby "2.2.3"
 
 # Specify your gem's dependencies in *.gemspec
 gemspec
+
+# Required to enable codeclimate's test coverage functionality
+gem "codeclimate-test-reporter", group: :test, require: nil

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # EA::AddressLookup
 
 [![Build Status](https://travis-ci.org/EnvironmentAgency/ea-address_lookup.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/ea-address_lookup)
+[![Code Climate](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup/badges/gpa.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup)
+[![Test Coverage](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup/badges/coverage.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup/coverage)
 
 This ruby gem provides address lookup functionality by postcode.
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
 require "simplecov"
 require "byebug"
 require "vcr"
@@ -5,12 +7,18 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ea/address_lookup'
 
 # Stubexternal services = see https://github.com/vcr/vcr
-VCR.configure do |c|
-  c.cassette_library_dir = "spec/cassettes"
-  c.hook_into :webmock
-  c.ignore_hosts "127.0.0.1"
-  c.allow_http_connections_when_no_cassette = false
-  c.default_cassette_options = {
+VCR.configure do |config|
+  # As per codeclimate "VCR [..] will prevent the codeclimate-test-reporter from
+  # reporting results to codeclimate.com" Recieved this error when first
+  # configuring integration to codeclimate and the fix is to add it to
+  # ignore_hosts.
+  config.ignore_hosts 'codeclimate.com'
+
+  config.cassette_library_dir = "spec/cassettes"
+  config.hook_into :webmock
+  config.ignore_hosts "127.0.0.1"
+  config.allow_http_connections_when_no_cassette = false
+  config.default_cassette_options = {
     record: :once
   }
 end


### PR DESCRIPTION
We believe that using metrics such as those provided by Codeclimate help us to ensure the quality of the code and artifacts we produce. This change integrates the repo with codeclimate by making the following changes

- Adding a .codeclimate.yml config file
- Adding the 'codeclimate-test-reporter' gem and configuring it to run in rspec
- Adding 'codeclimate.com' to VCR's ignore_host
- Configuring Travis to send test coverage stats to codeclimate after builds
- Adding the codeclimate badges to the README