### PR TITLE
Add before_commit to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-/.git-hooks/pre_commit/il8n_missing.rb
-/.git-hooks/pre_commit/il8n_unused.rb
-/.git-hooks/pre_commit/rspec_focus_check.rb
-/.overcommit.yml
-/.overcommit_gems.rb
-/.overcommit_gems.rb.lock
 /.bundle/
 /.yardoc
 /Gemfile.lock
@@ -12,7 +6,34 @@
 /doc/
 /pkg/
 /spec/reports/
+/spec/fixtures/results/*
 /tmp/
-.byebug_history
+
+# Ignore ruby_mine folder
+/.idea
+
+*~
 .DS_Store
+.svn
+.*.swp
+___*
+
+# Ignore bundler config.
+/.bundle
+
+# Ignore all logfiles and tempfiles.
+/log/*
+!/log/.keep
+
+# Overcommit configuration files (added by before_commit)
+.overcommit*
+.git-hooks/
+.rubocop.yml
+.htmlhintrc
+
+# Ignore developer specific .rspec files
 .rspec-local
+
+./ea-address_lookup*.gem
+
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 ruby "2.2.3"
 
 # Specify your gem's dependencies in *.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,8 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
+require 'before_commit'
+spec = Gem::Specification.find_by_name 'before_commit'
+load "#{spec.gem_dir}/lib/tasks/before_commit.rake"
+
 task default: :spec

--- a/ea-address_lookup.gemspec
+++ b/ea-address_lookup.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'ea/address_lookup/version'
+require "ea/address_lookup/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "ea-address_lookup"
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shoulda-matchers", "~> 3.1"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "byebug"
+  spec.add_development_dependency "before_commit"
 end

--- a/lib/ea/address_lookup/adapters.rb
+++ b/lib/ea/address_lookup/adapters.rb
@@ -3,28 +3,30 @@
 # interface to potentially varying address api interfaces.
 require "ea/address_lookup/adapters/address_facade"
 
-module EA::AddressLookup
-  module Adapters
-    def adapter
-      @adapter ||= create_adapter(EA::AddressLookup.config.default_adapter)
-    end
+module EA
+  module AddressLookup
+    module Adapters
+      def adapter
+        @adapter ||= create_adapter(EA::AddressLookup.config.default_adapter)
+      end
 
-    def adapter=(adapter_name)
-      @adapter = create_adapter(adapter_name)
-    end
+      def adapter=(adapter_name)
+        @adapter = create_adapter(adapter_name)
+      end
 
-    private
+      private
 
-    # Given an adpater_nam of e.g. :address_facade, return an instance of
-    # EA::AddressLookup::AddressLookup::Adapters::AddressFacade
-    def create_adapter(adapter_name)
-      raise MissingAdapterError if adapter_name.blank?
+      # Given an adpater_nam of e.g. :address_facade, return an instance of
+      # EA::AddressLookup::AddressLookup::Adapters::AddressFacade
+      def create_adapter(adapter_name)
+        raise MissingAdapterError if adapter_name.blank?
 
-      adapter_klass = adapter_name.to_s.classify.to_s
-      Adapters.const_get(adapter_klass).new
+        adapter_klass = adapter_name.to_s.classify.to_s
+        Adapters.const_get(adapter_klass).new
 
-    rescue NameError => ex
-      raise UnrecognisedAdapterError, adapter_name
+      rescue NameError
+        raise UnrecognisedAdapterError, adapter_name
+      end
     end
   end
 end

--- a/lib/ea/address_lookup/adapters/address_facade.rb
+++ b/lib/ea/address_lookup/adapters/address_facade.rb
@@ -31,84 +31,86 @@
 require "rest_client"
 require "benchmark"
 
-module EA::AddressLookup
-  module Adapters
-    class AddressFacade
-      attr_reader :base_url
+module EA
+  module AddressLookup
+    module Adapters
+      class AddressFacade
+        attr_reader :base_url
 
-      def reset
-        @base_url = nil
-      end
-
-      def base_url
-        @base_url ||= begin
-          server = EA::AddressLookup.config.address_facade_server
-          port = EA::AddressLookup.config.address_facade_port
-          url = EA::AddressLookup.config.address_facade_url
-          host = "http://#{server}:#{port}"
-          URI.join(host, url || "").to_s
+        def reset
+          @base_url = nil
         end
-      end
 
-      def find_by_uprn(uprn)
-        with_logging(:find_by_uprn, uprn) do
-          result = http_get(uprn)
-          parsed = parse_json(result)
+        def base_url
+          @base_url ||= begin
+            server = EA::AddressLookup.config.address_facade_server
+            port = EA::AddressLookup.config.address_facade_port
+            url = EA::AddressLookup.config.address_facade_url
+            host = "http://#{server}:#{port}"
+            URI.join(host, url || "").to_s
+          end
         end
-      end
 
-      def find_by_postcode(post_code)
-        with_logging(:find_by_postcode, post_code) do
-          result = http_get("postcode", postcode: post_code)
-          parsed = parse_json(result)
+        def find_by_uprn(uprn)
+          with_logging(:find_by_uprn, uprn) do
+            result = http_get(uprn)
+            parse_json(result)
+          end
         end
-      end
 
-      private
-
-      def default_query_params
-        {
-          'client-id': EA::AddressLookup.config.address_facade_client_id,
-          'key': EA::AddressLookup.config.address_facade_key
-        }
-      end
-
-      # The AddressBaseFacade is internal within AWS, so we need to
-      # ensure that we DO NOT use a proxy in http calls.
-      def http_get(path, query_params = {})
-        http_address = URI.join(base_url, path).to_s
-        result = RestClient::Request.execute(
-          method: :get,
-          url: http_address,
-          proxy: false,
-          headers: {
-            params: default_query_params.merge(query_params)
-          })
-      rescue => ex
-        raise ex if ex.class.to_s =~ /^VCR/
-        raise EA::AddressLookup::AddressServiceUnavailableError,
-              "#{http_address} "\
-              "params:#{default_query_params.merge(query_params)} - "\
-              "#{ex.message}"
-      end
-
-      def parse_json(json)
-        JSON.parse(json)
-      rescue => e
-        EA::AddressLookup.logger.error("Failed to parse JSON results "\
-                                       "#{e.message} #{json}")
-        {}
-      end
-
-      def with_logging(scope, arg, &block)
-        parsed_result = nil
-        time = Benchmark.realtime do
-          parsed_result = yield
+        def find_by_postcode(post_code)
+          with_logging(:find_by_postcode, post_code) do
+            result = http_get("postcode", postcode: post_code)
+            parse_json(result)
+          end
         end
-        EA::AddressLookup.logger.info "#{scope}(#{arg}) took "\
-                                       "#{sprintf('%05.2fms', time * 1000)}"
-        EA::AddressLookup.logger.debug "#{scope}(#{arg}) #{parsed_result}"
-        parsed_result
+
+        private
+
+        def default_query_params
+          {
+            'client-id': EA::AddressLookup.config.address_facade_client_id,
+            'key': EA::AddressLookup.config.address_facade_key
+          }
+        end
+
+        # The AddressBaseFacade is internal within AWS, so we need to
+        # ensure that we DO NOT use a proxy in http calls.
+        def http_get(path, query_params = {})
+          http_address = URI.join(base_url, path).to_s
+          RestClient::Request.execute(
+            method: :get,
+            url: http_address,
+            proxy: false,
+            headers: {
+              params: default_query_params.merge(query_params)
+            })
+        rescue => ex
+          raise ex if ex.class.to_s =~ /^VCR/
+          raise EA::AddressLookup::AddressServiceUnavailableError,
+                "#{http_address} "\
+                "params:#{default_query_params.merge(query_params)} - "\
+                "#{ex.message}"
+        end
+
+        def parse_json(json)
+          JSON.parse(json)
+        rescue => e
+          EA::AddressLookup.logger.error("Failed to parse JSON results "\
+                                         "#{e.message} #{json}")
+          {}
+        end
+
+        def with_logging(scope, arg)
+          parsed_result = nil
+          time = Benchmark.realtime do
+            parsed_result = yield
+          end
+          EA::AddressLookup.logger.info "#{scope}(#{arg}) took "\
+                                         "#{sprintf('%05.2fms', time * 1000)}"
+          EA::AddressLookup.logger.debug "#{scope}(#{arg}) #{parsed_result}"
+          parsed_result
+        end
       end
     end
   end

--- a/lib/ea/address_lookup/adapters/locate_api.rb
+++ b/lib/ea/address_lookup/adapters/locate_api.rb
@@ -2,21 +2,23 @@
 # Example of how me might define an Adaptor for
 # https://github.com/alphagov/locate-api
 #
-module EA::AddressLookup
-  module Adapters
-    module LocateApi
-      extend self
+module EA
+  module AddressLookup
+    module Adapters
+      module LocateApi
+        module_function
 
-      def url
-        Rails.configuration.dcs_locate_api_url
-      end
+        def url
+          Rails.configuration.dcs_locate_api_url
+        end
 
-      def find_by_postcode(post_code)
-        result = RestClient::Request.execute(method: :get,
-                                             url: url,
-                                             proxy: false,
-                                             params: { postcode: post_code })
-        JSON.parse(result)
+        def find_by_postcode(post_code)
+          result = RestClient::Request.execute(method: :get,
+                                               url: url,
+                                               proxy: false,
+                                               params: { postcode: post_code })
+          JSON.parse(result)
+        end
       end
     end
   end

--- a/lib/ea/address_lookup/configuration.rb
+++ b/lib/ea/address_lookup/configuration.rb
@@ -1,25 +1,27 @@
 require "active_support/configurable"
 
-module EA::AddressLookup
-  class Configuration
-    include ActiveSupport::Configurable
-    config_accessor(:address_facade_server)
-    config_accessor(:address_facade_port)
-    config_accessor(:address_facade_url)
-    config_accessor(:address_facade_client_id)
-    config_accessor(:address_facade_key)
-    config_accessor(:default_adapter) { :address_facade }
-  end
+module EA
+  module AddressLookup
+    class Configuration
+      include ActiveSupport::Configurable
+      config_accessor(:address_facade_server)
+      config_accessor(:address_facade_port)
+      config_accessor(:address_facade_url)
+      config_accessor(:address_facade_client_id)
+      config_accessor(:address_facade_key)
+      config_accessor(:default_adapter) { :address_facade }
+    end
 
-  def self.config
-    @config ||= Configuration.new
-  end
+    def self.config
+      @config ||= Configuration.new
+    end
 
-  def self.configure
-    yield config
-  end
+    def self.configure
+      yield config
+    end
 
-  def self.reset
-    @config = Configuration.new
+    def self.reset
+      @config = Configuration.new
+    end
   end
 end

--- a/lib/ea/address_lookup/errors.rb
+++ b/lib/ea/address_lookup/errors.rb
@@ -1,5 +1,7 @@
-module EA::AddressLookup
-  class MissingAdapterError < StandardError; end
-  class UnrecognisedAdapterError < StandardError; end
-  class AddressServiceUnavailableError < StandardError; end
+module EA
+  module AddressLookup
+    class MissingAdapterError < StandardError; end
+    class UnrecognisedAdapterError < StandardError; end
+    class AddressServiceUnavailableError < StandardError; end
+  end
 end

--- a/lib/ea/address_lookup/finders.rb
+++ b/lib/ea/address_lookup/finders.rb
@@ -1,13 +1,15 @@
 require "ea/address_lookup/adapters/address_facade"
 
-module EA::AddressLookup
-  module Finders
-    def find_by_postcode(post_code)
-      adapter.find_by_postcode(post_code)
-    end
+module EA
+  module AddressLookup
+    module Finders
+      def find_by_postcode(post_code)
+        adapter.find_by_postcode(post_code)
+      end
 
-    def find_by_uprn(uprn)
-      adapter.find_by_uprn(uprn)
+      def find_by_uprn(uprn)
+        adapter.find_by_uprn(uprn)
+      end
     end
   end
 end

--- a/lib/ea/address_lookup/logger.rb
+++ b/lib/ea/address_lookup/logger.rb
@@ -4,14 +4,16 @@
 #  EA::AddressLookup.logger.level = Logger::ERROR
 require "logger"
 
-module EA::AddressLookup
-  class << self
-    attr_writer :logger
+module EA
+  module AddressLookup
+    class << self
+      attr_writer :logger
 
-    def logger
-      @logger ||= Logger.new($stdout).tap do |log|
-        log.progname = self.name
-        log.level = Logger::DEBUG
+      def logger
+        @logger ||= Logger.new($stdout).tap do |log|
+          log.progname = name
+          log.level = Logger::DEBUG
+        end
       end
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe EA::AddressLookup::Configuration do
   let(:config) { EA::AddressLookup.config }
 
-  it {is_expected.to respond_to(:default_adapter) }
+  it { is_expected.to respond_to(:default_adapter) }
 
   describe "#configure" do
     it "can set and get configuration options" do

--- a/spec/ea/address_lookup/adapters/address_facade_adapter_spec.rb
+++ b/spec/ea/address_lookup/adapters/address_facade_adapter_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 describe EA::AddressLookup::Adapters::AddressFacade do
   before do
     EA::AddressLookup.configure do |config|
-      config.address_facade_server = server #'addressfacade.cloudapp.net'
+      config.address_facade_server = server # 'addressfacade.cloudapp.net'
       config.address_facade_port = ""
-      config.address_facade_url = url# '/address-service/v1/addresses/'
-      config.address_facade_client_id = client_id# 'example team'
+      config.address_facade_url = url # '/address-service/v1/addresses/'
+      config.address_facade_client_id = client_id # 'example team'
       config.address_facade_key = key # 'client1'
     end
   end
@@ -34,7 +34,7 @@ describe EA::AddressLookup::Adapters::AddressFacade do
         VCR.use_cassette("adapter_find_by_postcode") do
           response = subject.find_by_postcode("BS6 5QA")
           expect(response).to be_an_instance_of(Hash)
-          expect(response.has_key?("results")).to be true
+          expect(response.key?("results")).to be true
           expect(response["results"]).to be_instance_of Array
           expect(response["results"].size).to be > 4
         end
@@ -44,7 +44,7 @@ describe EA::AddressLookup::Adapters::AddressFacade do
         VCR.use_cassette("adapter_find_by_uprn") do
           response = subject.find_by_uprn("77138")
           expect(response).to be_an_instance_of(Hash)
-          expect(response.has_key?("results")).to be true
+          expect(response.key?("results")).to be true
           expect(response["results"]).to be_instance_of Array
           expect(response["results"].size).to be 1
         end

--- a/spec/ea/address_lookup/adapters_spec.rb
+++ b/spec/ea/address_lookup/adapters_spec.rb
@@ -11,7 +11,9 @@ describe EA::AddressLookup do
     end
 
     describe "#adpater=" do
+      # rubocop:disable Style/ClassAndModuleChildren
       class ::EA::AddressLookup::Adapters::TestAdapter2; end
+      # rubocop:enable Style/ClassAndModuleChildren
 
       it "assigns a matching adapter class" do
         described_class.adapter = :test_adapter2
@@ -20,7 +22,7 @@ describe EA::AddressLookup do
       end
 
       it "raises an error nil passed" do
-        expect { described_class.adapter = nil}
+        expect { described_class.adapter = nil }
           .to raise_error(EA::AddressLookup::MissingAdapterError)
       end
 

--- a/spec/ea/address_lookup/address_lookup_spec.rb
+++ b/spec/ea/address_lookup/address_lookup_spec.rb
@@ -5,7 +5,10 @@ describe EA::AddressLookup do
   it { is_expected.to respond_to :find_by_uprn }
 
   describe "find* methods delegate to the adpater" do
+    # rubocop:disable Style/ClassAndModuleChildren
     class ::EA::AddressLookup::Adapters::TestAdapter; end
+    # rubocop:enable Style/ClassAndModuleChildren
+
     %i(find_by_postcode find_by_uprn).each do |method|
       it "delegates #{method} to the adapter" do
         arg = "XXX"


### PR DESCRIPTION
We have developed a tool which holds and manages various linters and checkers we run against each project. We use this in an attempt to keep the quality of the code high and consistent across the team.

This change adds a reference in the gemspec to the [before_commit](https://github.com/EnvironmentAgency/ea-address_lookup) gem, as well as any additional configuration files for use with the tools.