### PR TITLE
Add an http timeout with a sensible default

### DIFF
--- a/ea-address_lookup.gemspec
+++ b/ea-address_lookup.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 4.2"
   spec.add_dependency "rest-client", "~> 2.0.0.rc2"
+  spec.add_dependency "nesty", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/ea/address_lookup/adapters/address_facade.rb
+++ b/lib/ea/address_lookup/adapters/address_facade.rb
@@ -43,9 +43,9 @@ module EA
 
         def base_url
           @base_url ||= begin
-            server = EA::AddressLookup.config.address_facade_server
-            port = EA::AddressLookup.config.address_facade_port
-            url = EA::AddressLookup.config.address_facade_url
+            server = config.address_facade_server
+            port = config.address_facade_port
+            url = config.address_facade_url
             host = "http://#{server}:#{port}"
             URI.join(host, url || "").to_s
           end
@@ -69,9 +69,17 @@ module EA
 
         def default_query_params
           {
-            'client-id': EA::AddressLookup.config.address_facade_client_id,
-            'key': EA::AddressLookup.config.address_facade_key
+            'client-id': config.address_facade_client_id,
+            'key': config.address_facade_key
           }
+        end
+
+        def config
+          EA::AddressLookup.config
+        end
+
+        def logger
+          EA::AddressLookup.logger
         end
 
         # The AddressBaseFacade is internal within AWS, so we need to
@@ -82,7 +90,7 @@ module EA
             method: :get,
             url: http_address,
             proxy: false,
-            timeout: EA::AddressLookup.config.timeout_in_seconds,
+            timeout: config.timeout_in_seconds,
             headers: {
               params: default_query_params.merge(query_params)
             })
@@ -97,7 +105,7 @@ module EA
         def parse_json(json)
           JSON.parse(json)
         rescue => e
-          EA::AddressLookup.logger.error("Failed to parse JSON results "\
+          logger.error("Failed to parse JSON results "\
                                          "#{e.message} #{json}")
           {}
         end
@@ -107,9 +115,9 @@ module EA
           time = Benchmark.realtime do
             parsed_result = yield
           end
-          EA::AddressLookup.logger.info "#{scope}(#{arg}) took "\
+          logger.info "#{scope}(#{arg}) took "\
                                          "#{sprintf('%05.2fms', time * 1000)}"
-          EA::AddressLookup.logger.debug "#{scope}(#{arg}) #{parsed_result}"
+          logger.debug "#{scope}(#{arg}) #{parsed_result}"
           parsed_result
         end
       end

--- a/lib/ea/address_lookup/adapters/address_facade.rb
+++ b/lib/ea/address_lookup/adapters/address_facade.rb
@@ -82,6 +82,7 @@ module EA
             method: :get,
             url: http_address,
             proxy: false,
+            timeout: EA::AddressLookup.config.timeout_in_seconds,
             headers: {
               params: default_query_params.merge(query_params)
             })

--- a/lib/ea/address_lookup/configuration.rb
+++ b/lib/ea/address_lookup/configuration.rb
@@ -9,6 +9,7 @@ module EA
       config_accessor(:address_facade_url)
       config_accessor(:address_facade_client_id)
       config_accessor(:address_facade_key)
+      config_accessor(:timeout_in_seconds) { 5 }
       config_accessor(:default_adapter) { :address_facade }
     end
 

--- a/lib/ea/address_lookup/errors.rb
+++ b/lib/ea/address_lookup/errors.rb
@@ -1,7 +1,15 @@
+require "nesty"
+
 module EA
   module AddressLookup
-    class MissingAdapterError < StandardError; end
-    class UnrecognisedAdapterError < StandardError; end
-    class AddressServiceUnavailableError < StandardError; end
+    class MissingAdapterError < StandardError
+      include Nesty::NestedError
+    end
+    class UnrecognisedAdapterError < StandardError
+      include Nesty::NestedError
+    end
+    class AddressServiceUnavailableError < StandardError
+      include Nesty::NestedError
+    end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -13,12 +13,14 @@ describe EA::AddressLookup::Configuration do
         c.address_facade_url = "c"
         c.address_facade_client_id = "d"
         c.address_facade_key = "e"
+        c.timeout_in_seconds = 11
       end
       expect(config.address_facade_server).to eq "a"
       expect(config.address_facade_port).to eq "b"
       expect(config.address_facade_url).to eq "c"
       expect(config.address_facade_client_id).to eq "d"
       expect(config.address_facade_key).to eq "e"
+      expect(config.timeout_in_seconds).to eq 11
     end
   end
 
@@ -33,6 +35,9 @@ describe EA::AddressLookup::Configuration do
   describe "defaults" do
     it "has a default_adapter" do
       expect(config.default_adapter).to_not be_blank
+    end
+    it "has a default timeout" do
+      expect(config.timeout_in_seconds).to_not be_blank
     end
   end
 end


### PR DESCRIPTION
Add a `timeout_in_seconds` configuration value with a default of 5 seconds to prevent user frustration.
Use this timeout in value when calling the AddressBasedFacade.