### PR TITLE
Handle VCR ISP 404s in offnet development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ rvm:
   - 2.3.1
 
 before_install:
-  - nvm install node
   - gem install bundler -v 1.11.2
 
 bundler_args: --binstubs=./bundler_stubs
 
 before_script:
-  - npm install -g jshint coffeelint htmlhint csslint # overcommit packages
 
 script:
   - bundle exec rake --trace before_commit:run_without_checks

--- a/lib/ea/address_lookup/adapters/address_facade.rb
+++ b/lib/ea/address_lookup/adapters/address_facade.rb
@@ -86,20 +86,26 @@ module EA
         # ensure that we DO NOT use a proxy in http calls.
         def http_get(path, query_params = {})
           http_address = URI.join(base_url, path).to_s
-          RestClient::Request.execute(
-            method: :get,
-            url: http_address,
-            proxy: false,
-            timeout: config.timeout_in_seconds,
-            headers: {
-              params: default_query_params.merge(query_params)
-            })
+          args = build_request_args(http_address, query_params)
+          RestClient::Request.execute(args)
         rescue => ex
           raise ex if ex.class.to_s =~ /^VCR/
           raise EA::AddressLookup::AddressServiceUnavailableError,
                 "#{http_address} "\
                 "params:#{default_query_params.merge(query_params)} - "\
                 "#{ex.message}"
+        end
+
+        def build_request_args(http_address, query_params)
+          {
+            method: :get,
+            url: http_address,
+            proxy: false,
+            timeout: config.timeout_in_seconds,
+            headers: {
+              params: default_query_params.merge(query_params)
+            }
+          }
         end
 
         def parse_json(json)

--- a/spec/ea/address_lookup/adapters/address_facade_adapter_spec.rb
+++ b/spec/ea/address_lookup/adapters/address_facade_adapter_spec.rb
@@ -68,7 +68,14 @@ describe EA::AddressLookup::Adapters::AddressFacade do
     context "bad server" do
       let(:server) { "addressfacade.nosuchplaceinthewww.junk" }
       it "raises an exception when service cannot be reached for uprn search" do
-        VCR.use_cassette("adaptor_no_such_server_uprn") do
+        # An issue here: if you run this in the EA office, you get a 404 and the
+        # cassette is not even used; if you run elsewhere an ISP might return
+        # a custom 404 page (with a 200 code) in which case the cassette is created
+        # and is totally wrong. There are ways you can disable the ISPs 404 for
+        # example by setting custom DNS servers (eg e.g. Google's) in the router.
+        # So if you are running these tests from hoome and have a VCR error,
+        # please ignore and treat CI results as the source of truth!
+        VCR.use_cassette("adaptor_no_such_server_uprn", record: :once) do
           expect {
             subject.find_by_uprn("77138")
           }.to raise_error EA::AddressLookup::AddressServiceUnavailableError
@@ -76,7 +83,7 @@ describe EA::AddressLookup::Adapters::AddressFacade do
       end
 
       it "raises an exception when service unreachable for postcode search" do
-        VCR.use_cassette("adaptor_no_such_server_postcode") do
+        VCR.use_cassette("adaptor_no_such_server_postcode", record: :once) do
           expect {
             subject.find_by_postcode("BS1 1AH")
           }.to raise_error EA::AddressLookup::AddressServiceUnavailableError

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ VCR.configure do |config|
   config.ignore_hosts "127.0.0.1"
   config.allow_http_connections_when_no_cassette = false
   config.default_cassette_options = {
-    record: :once
+    record: :none
   }
 end
 


### PR DESCRIPTION
If developing in an environment where ISPs can return a code 200 custom 404 page
handle by failing without creating the 'wrong' VCR cassettes.
Add a comment as to why the failure is occurring.