### PR TITLE
Add helper used in host apps to stub EA::AddressLookup methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,32 @@ hash = EA::AddressLookup.find_by_postcode('BA1 5AH')
 hash = EA::AddressLookup.find_by_uprn('12345678')
 ```
 
+## Testing with RSpec
+A test helper is included that provides methods that will stub calls to
+EA::AddressLookup methods in RSpec tests. To enable them add this to
+the rspec configuration (for example, within a `RSpec.configure do |config|`
+block in a Rails app's `spec/rails_helper.rb`):
+
+```ruby
+config.include EA::AddressLookup::TestHelper::RspecMocks
+```
+
+This will make the methods defined in `lib/ea/address_lookup/test_helper/rspec_mocks.rb`
+available within the host app's rspec tests. For example:
+
+```ruby
+describe "postcode lookup" do
+  before do
+    mock_ea_address_lookup_find_by_postcode
+  end
+
+  it "some tests that use data returned by a postcode lookup" do
+    ....
+  end
+end
+```
+
+
 ## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.

--- a/lib/ea/address_lookup.rb
+++ b/lib/ea/address_lookup.rb
@@ -5,6 +5,7 @@ require "ea/address_lookup/logger"
 require "ea/address_lookup/errors"
 require "ea/address_lookup/adapters"
 require "ea/address_lookup/finders"
+require "ea/address_lookup/test_helper/rspec_mocks"
 
 module EA
   module AddressLookup

--- a/lib/ea/address_lookup/test_helper/address_lookup.yml
+++ b/lib/ea/address_lookup/test_helper/address_lookup.yml
@@ -1,0 +1,64 @@
+---
+uprn_lookup:
+  totalMatches: 1
+  startMatch: 1
+  endMatch: 1
+  uri_to_supplier: https://api.ordnancesurvey.co.uk/places/v1/addresses/uprn?uprn=10010175140&lr=EN&dataset=DPA
+  uri_from_client: stub
+  results:
+    - uprn: 340116
+      address: ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH
+      organisation: ENVIRONMENT AGENCY
+      premises: HORIZON HOUSE
+      street_address: DEANERY ROAD
+      locality: SOMEWHERE
+      city: BRISTOL
+      postcode: BS1 5AH
+      x: 358205.03
+      y: 172708.07
+      coordinate_system: ""
+      state_date: 12/10/2009
+      blpu_state_code: ""
+      postal_address_code: ""
+      logical_status_code: ""
+      source_data_type: dpa
+
+postcode_lookup:
+  totalMatches: 2
+  startMatch: 1
+  endMatch: 2
+  uri_to_supplier: "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=BS1%205AH&maxresults=100&dataset=DPA"
+  uri_from_client: stub
+  results:
+    - uprn: 340116
+      address: ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH
+      organisation: ENVIRONMENT AGENCY
+      premises: HORIZON HOUSE
+      street_address: DEANERY ROAD
+      locality: ""
+      city: BRISTOL
+      postcode: BS1 5AH
+      x: 358205.03
+      y: 172708.07
+      coordinate_system: ""
+      state_date: 12/10/2009
+      blpu_state_code: ""
+      postal_address_code: ""
+      logical_status_code: ""
+      source_data_type: dpa
+    - uprn: 10091760640
+      address: HARMSEN GROUP, TRIODOS BANK, DEANERY ROAD, BRISTOL, BS1 5AH
+      organisation: HARMSEN GROUP
+      premises: TRIODOS BANK
+      street_address: DEANERY ROAD
+      locality: ""
+      city: BRISTOL
+      postcode: BS1 5AH
+      x: 358130.1
+      y: 172687.87
+      coordinate_system: ""
+      state_date: ""
+      blpu_state_code: ""
+      postal_address_code: ""
+      logical_status_code: ""
+      source_data_type: dpa

--- a/lib/ea/address_lookup/test_helper/mock_data.rb
+++ b/lib/ea/address_lookup/test_helper/mock_data.rb
@@ -1,0 +1,32 @@
+module EA
+  module AddressLookup
+    module TestHelper
+      class MockData
+
+        def initialize(file_name)
+          @file_name = file_name.to_s.strip
+        end
+
+        def data_for(key)
+          yaml[key.to_s]
+        end
+
+        private
+
+        def file_name
+          return @file_name if @file_name =~ /\.yml$/
+          "#{@file_name}.yml"
+        end
+
+        def path
+          File.expand_path file_name, File.dirname(__FILE__)
+        end
+
+        def yaml
+          @yaml ||= YAML.load_file path
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ea/address_lookup/test_helper/rspec_mocks.rb
+++ b/lib/ea/address_lookup/test_helper/rspec_mocks.rb
@@ -1,0 +1,41 @@
+require_relative "mock_data"
+module EA
+  module AddressLookup
+    module TestHelper
+      # Uses data from address_lookup.yml to mock calls to EA::AddressLookup methods
+      module RspecMocks
+
+        def mock_ea_address_lookup_find_by_uprn
+          allow(EA::AddressLookup)
+            .to receive(:find_by_uprn)
+            .and_return(mock_data.data_for(:uprn_lookup))
+        end
+
+        def mock_failure_of_ea_address_lookup_find_by_uprn
+          allow(EA::AddressLookup)
+            .to receive(:find_by_uprn)
+            .and_raise(AddressServiceUnavailableError, "Whoops")
+        end
+
+        def mock_ea_address_lookup_find_by_postcode
+          allow(EA::AddressLookup)
+            .to receive(:find_by_postcode)
+            .and_return(mock_data.data_for(:postcode_lookup))
+        end
+
+        def mock_failure_of_ea_address_lookup_find_by_postcode
+          allow(EA::AddressLookup)
+            .to receive(:find_by_postcode)
+            .and_raise(AddressServiceUnavailableError, "Whoops")
+        end
+
+        private
+
+        def mock_data
+          @mock_data ||= MockData.new :address_lookup
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ea/address_lookup/version.rb
+++ b/lib/ea/address_lookup/version.rb
@@ -1,5 +1,5 @@
 module EA
   module AddressLookup
-    VERSION = "0.2.0".freeze
+    VERSION = "0.3.0".freeze
   end
 end

--- a/spec/ea/address_lookup/test_helper/mock_data_spec.rb
+++ b/spec/ea/address_lookup/test_helper/mock_data_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+module EA
+  module AddressLookup
+    module TestHelper
+      describe MockData do
+        let(:mock_data) { described_class.new(:address_lookup) }
+        let!(:address_facade) { Adapters::AddressFacade.new }
+
+        before do
+          EA::AddressLookup.configure do |config|
+            config.address_facade_server = server # 'someaddressfacadeservice.net'
+            config.address_facade_port = ""
+            config.address_facade_url = url # '/address-service/v1/addresses/'
+            config.address_facade_client_id = client_id # 'example team'
+            config.address_facade_key = key # 'client1'
+          end
+        end
+        let(:server)      { "someaddressfacadeservice.net" }
+        let(:url)         { "/address-service/v1/addresses/" }
+        let(:key)         { "client1" }
+        let(:client_id)   { "example team1" }
+
+        let!(:uprn_response) do
+          VCR.use_cassette("adapter_find_by_uprn") do
+            address_facade.find_by_uprn("77138")
+          end
+        end
+
+        let!(:postcode_response) do
+          VCR.use_cassette("adapter_find_by_postcode") do
+            address_facade.find_by_postcode("BS6 5QA")
+          end
+        end
+
+        describe "#data_for" do
+          context "with :uprn_lookup" do
+            let(:data) { mock_data.data_for :uprn_lookup }
+
+            it "should match the root keys" do
+              expect(data.keys.sort).to eq(uprn_response.keys.sort)
+            end
+
+            it "should match results keys" do
+              expect(data["results"].first.keys.sort)
+                .to eq(uprn_response["results"].first.keys.sort)
+            end
+          end
+
+          context "with :postcode_lookup" do
+            let(:data) { mock_data.data_for :postcode_lookup }
+
+            it "should match the root keys" do
+              expect(data.keys.sort).to eq(postcode_response.keys.sort)
+            end
+
+            it "should match the root keys" do
+              expect(data["results"].first.keys.sort)
+                .to eq(postcode_response["results"].first.keys.sort)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this in place you can:

```
describe "postcode lookup" do
  before do
    mock_ea_address_lookup_find_by_postcode
  end

  it "some tests that use data returned by a postcode lookup" do
    ....
  end
end
```