### PR TITLE
Integrate project with Hakiri

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # EA::AddressLookup
 
 [![Build Status](https://travis-ci.org/EnvironmentAgency/ea-address_lookup.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/ea-address_lookup)
+[![security](https://hakiri.io/github/EnvironmentAgency/ea-address_lookup/master.svg)](https://hakiri.io/github/EnvironmentAgency/ea-address_lookup/master)
 [![Code Climate](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup/badges/gpa.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup)
 [![Test Coverage](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup/badges/coverage.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup/coverage)
 [![Gem Version](https://badge.fury.io/rb/ea-address_lookup.svg)](https://badge.fury.io/rb/ea-address_lookup)

--- a/ea-address_lookup.gemspec
+++ b/ea-address_lookup.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 4.2"
+  spec.add_dependency "activesupport", ">= 4.2.2"
   spec.add_dependency "rest-client", "~> 2.0.0.rc2"
   spec.add_dependency "nesty", "~> 1.0"
 


### PR DESCRIPTION
[Hakiri](https://hakiri.io) is an online security tool which scans the dependencies of a project for known vulnerabilities. We have committed to adding it to all our open source projects, as its simple to do and increases security of the code and services that use it.