### PR TITLE
Switch to SonarCloud from CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,24 @@
-language: ruby
-cache: bundler
-rvm:
-  - 2.3.1
-before_install:
-  - gem install bundler -v 1.11.2
-bundler_args: "--binstubs=./bundler_stubs"
-before_script:
-script:
-  - bundle exec rake --trace before_commit:run_without_checks
-  - git config --global user.email test@example.com
-  - git config --global user.name "Test Example"
-  - BUNDLE_GEMFILE=.overcommit_gems.rb bundle exec overcommit --run
-  - bundle exec rspec
-branches:
-  only:
-    - master
+dist: trusty
+
 addons:
-  code_climate:
-    repo_token:
-      secure: NHoT4H5wYUhdGoByjcnViaLzHFkxKgSgZPCNtWtaCdrWXUwX8VLYYl6NPqvANMII0z81Fq8P0+Nzo0o0YfWAvXsimsuhXd4hdzMSKW+xp6G5KRmCaU8FfIjqGhf0yYs3jmTD6Bz2rv1uhZ080k39OXBE/pGR3pkd229lVxrVR91zYYnERqNGD7p78NDGCTPlyoYYNB+wMLq76p6Hl2dSZgwMQtDS/Qi95vG+3Zq2y3z+iarlXSxm2xqfYMgUTcoO3w1eL2P/I+y/SqKgqKEpNKTzicFySUUg5NEvQy/GQit6iArkemU3q364fp4RqkUzauDenEsE64Q6MNY/n7Pj+ZVUKvT3mFKr2OAQojrJko2vtM7QuxBKmaRvkA89JRJvXDTREqbB1gY9pmnAbxBQbRW25KRSucKRPIGhK+gfwjM01eINveR86KECyTOLkrVcWFihrXzrIxLzv37UQUh9UVE/+aca0QVivYa6jJOebPKeLxS3sPLco8clv4A1H7HfvAkzg9lzWC6cz/cSOmQWWvAcDsd+riMaq188fCGuPhHcGywzwH4qt/75b8vnOoOSZSxqNAvQfsf0np0V+N2ahiGqpBhTgPKD3B+Mhff2KN0WY0eejzUMdPdi6zNcjJySyvLBZ9Jrmb+Vf/X1DhEqg05n/V2lQCWzoeJw4zSyRyU=
-deploy:
-  provider: rubygems
-  api_key:
-    secure: BQYV2mKJ4LItAiYgYSW1ixVMIlk1ahzvbMXJz/xtH2XfZzT7T6r17VbjpH2pbJo5QbChwsWaZOAZq2nrPIsgrh09/liflZC010Qc60zIYqgB4LXOu7KM6XEpfSvc/NCf0NwPExIjF2jskuhAwQXJVWLCcDGEyUEGnNhn5NDPq7TXR9U0sQyY1MZfJvlQwUNgaOThGA7b6DzUiim7LpGTAs7PcBHKfgwr1hRqVQ0VMF1jZsdvVID9IPVqfojOrNnAzoN2MpgybhsUTkSueV6WaWPhbY0eXH2U0EKx9grlyb0TBHfYVSADC8tNKB/ooJv6ofHfL+cZTki4+gCKOmv+vs2IkNqs1fucLMwDaE48sI/9omvyPPD4t1SMAhA+IBCUGQdXz8CvIsLf6gf/N8srQnUv8QiAoHw1ArkCt4Y2D1iYAf8r+XGP4nuewVJwNHG+9qQILDz4xlCPUJFtBdbiDo1RjazoLtOhTfnSemXeDVl+GUE09fzO3iclBAN2wiGGLRy57SEs+VkQLmPGb9aaJ+LXuMgtr1lzqX0x4JdyG690qCoZcRF+uwDcnBX+HjJcZOzcHORpOlqJM8LaFl86oo3DrdnvJgpkumn3LllsS2CYOO191b3nWnN0lbEuLpT0TbtO4Mhk/YwDG9VZpbwAATiLBMd0IiAmlGbdZMw9ias=
-  gem: ea-address_lookup
-  on:
-    tags: true
-    repo: EnvironmentAgency/ea-address_lookup
+  sonarcloud:
+    organization: "defra"
+
+language: ruby
+rvm: 2.3.1
+cache: bundler
+
+# Travis CI uses shallow clone to speed up build times, but a truncated SCM
+# history may cause issues when SonarCloud computes blame data. To avoid this,
+# you can access the full SCM history with `depth: false`
+git:
+  depth: false
+
+before_install:
+  - export TZ=UTC
+  - gem install -v 1.17.3 bundler --no-document
+
+script:
+  - bundle exec rubocop --format=json --out=rubocop-result.json
+  - bundle exec rspec
+  - sonar-scanner

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,5 @@ before_install:
   - gem install -v 1.17.3 bundler --no-document
 
 script:
-  - bundle exec rubocop --format=json --out=rubocop-result.json
   - bundle exec rspec
   - sonar-scanner

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,3 @@ ruby "2.3.1"
 
 # Specify your gem's dependencies in *.gemspec
 gemspec
-
-# Required to enable codeclimate's test coverage functionality
-gem "codeclimate-test-reporter", group: :test, require: nil

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # EA::AddressLookup
 
-[![Build Status](https://travis-ci.org/EnvironmentAgency/ea-address_lookup.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/ea-address_lookup)
-[![security](https://hakiri.io/github/EnvironmentAgency/ea-address_lookup/master.svg)](https://hakiri.io/github/EnvironmentAgency/ea-address_lookup/master)
-[![Code Climate](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup/badges/gpa.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup)
-[![Test Coverage](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup/badges/coverage.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-address_lookup/coverage)
+[![Build Status](https://travis-ci.com/DEFRA/ea-address_lookup.svg?branch=master)](https://travis-ci.com/DEFRA/ea-address_lookup)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_ea-address_lookup&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_ea-address_lookup)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_ea-address_lookup&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_ea-address_lookup)
+[![security](https://hakiri.io/github/DEFRA/ea-address_lookup/master.svg)](https://hakiri.io/github/DEFRA/ea-address_lookup/master)
 [![Gem Version](https://badge.fury.io/rb/ea-address_lookup.svg)](https://badge.fury.io/rb/ea-address_lookup)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
 This ruby gem provides address lookup functionality by postcode.
 
@@ -38,7 +39,7 @@ Create an intializer eg `config/initializers/address_lookup.rb`
 EA::AddressLookup.configure do |config|
   config.address_facade_server = <some_host_name>
   config.address_facade_port = ""
-  config.address_facade_url = "/address-service/v1/addresses/""
+  config.address_facade_url = "/address-service/v1/addresses/"
   config.address_facade_client_id = <client_id>
   config.address_facade_key = <key>
 end
@@ -53,12 +54,13 @@ hash = EA::AddressLookup.find_by_uprn('12345678')
 ```
 
 ## Testing with RSpec
+
 A test helper is included that provides methods that will stub calls to
 EA::AddressLookup methods in RSpec tests.
 
 The available mock methods are:
 
-```
+```ruby
 mock_ea_address_lookup_find_by_uprn
 mock_failure_of_ea_address_lookup_find_by_uprn
 mock_ea_address_lookup_find_by_postcode
@@ -131,7 +133,7 @@ All contributions should be submitted via a pull request.
 
 THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 
-http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+<http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3>
 
 The following attribution statement MUST be cited in your products and applications when using this information.
 

--- a/ea-address_lookup.gemspec
+++ b/ea-address_lookup.gemspec
@@ -6,12 +6,11 @@ require "ea/address_lookup/version"
 Gem::Specification.new do |spec|
   spec.name          = "ea-address_lookup"
   spec.version       = EA::AddressLookup::VERSION
-  spec.authors       = ["Digital Services Team, EnvironmentAgency"]
-  spec.email         = ["dst@environment-agency.gov.uk"]
-
+  spec.authors       = ["Defra"]
+  spec.email         = ["alan.cruikshanks@environment-agency.gov.uk"]
+  spec.homepage      = "https://github.com/DEFRA/ea-address_lookup"
   spec.summary       = "Address lookup by postcode"
   spec.description   = "This gem is a wrapper around services which provide address lookup by postcode."
-  spec.homepage      = "https://github.com/EnvironmentAgency"
   spec.license       = "The Open Government Licence (OGL) Version 3"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
@@ -23,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rest-client", "~> 2.0.0.rc2"
   spec.add_dependency "nesty", "~> 1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "vcr", "~> 3.0"
@@ -31,5 +29,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shoulda-matchers", "~> 3.1"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency "before_commit"
 end

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,4 +27,3 @@ sonar.tests=./spec
 sonar.sourceEncoding=UTF-8
 
 sonar.ruby.coverage.reportPath=coverage/.resultset.json
-sonar.ruby.rubocop.reportPaths=rubocop-result.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,30 @@
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_ea-address_lookup
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI
+sonar.projectName=ea-address_lookup
+sonar.projectVersion=0.2.0
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/ea-address_lookup
+sonar.links.ci=https://travis-ci.com/DEFRA/ea-address_lookup
+sonar.links.scm=https://github.com/DEFRA/ea-address_lookup
+sonar.links.issue=https://github.com/DEFRA/ruby-services-team/issues
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on
+# Windows.
+# Because rails generates a number of files, and SonarCloud has no rails and
+# ruby intelligence we have found we have to specify what should be covered.
+# If we don't SonarCloud will do things like take the raw coverage data from
+# simplecov, compare that to all files ion the repo, and score 0 for all the
+# files we don't actually need to test. This severly deflates our scores and
+# means it is not consistent with our previous reporting tool CodeClimate.
+sonar.sources=./lib
+sonar.tests=./spec
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.rubocop.reportPaths=rubocop-result.json

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
 require "simplecov"
 require "byebug"
 require "vcr"


### PR DESCRIPTION
https://sonarcloud.io/organizations/defra/projects

We currently use [Code Climate](https://codeclimate.com/) for our code quality checks and test coverage analysis. However a number of Defra projects have used an internal SonarQube instance, and some public ones have been using SonarCloud (the cloud SASS version of SonarQube).

It looks like we're about to formally adopt SonarCloud and all projects will coalesce onto. So to keep on top of things and continue to be an example to others, we are working through our repos and switching them to SonarCloud.

** Notes

The figuring out of how to do this (because it wasn't straight forward!) was done in

- https://github.com/DEFRA/waste-exemptions-front-office/pull/317
- https://github.com/DEFRA/waste-exemptions-front-office/pull/318

This change also includes a few minor tweaks and updates to info in the gemspec and README.